### PR TITLE
Add support of discard with treshold option, remake the solution usin…

### DIFF
--- a/group_options.go
+++ b/group_options.go
@@ -3,10 +3,11 @@ package syncs
 import "context"
 
 type options struct {
-	ctx           context.Context
-	preLock       bool
-	termOnError   bool
-	discardIfFull bool
+	ctx             context.Context
+	preLock         bool
+	termOnError     bool
+	discardIfFull   bool
+	tresholdDiscard int
 }
 
 // GroupOption functional option type
@@ -33,4 +34,20 @@ func TermOnErr(o *options) {
 func Discard(o *options) {
 	o.discardIfFull = true
 	o.preLock = true // discard implies preemptive
+}
+
+// DiscardAfterTreshold works similarly to Discard, but buffers task until buffer treshold reach
+// For example, if 10 gouroutines are allowed and bufferTreshold is equal to 5, then 10 tasks
+// can run simultaneously in gouroutines and 5 tasks can be kept in buffer until gouroutines become
+// available.
+func DiscardAfterTreshold(bufferSize int) GroupOption {
+	return func(o *options) {
+		o.discardIfFull = true
+		o.preLock = true
+
+		if bufferSize < 1 {
+			bufferSize = 0
+		}
+		o.tresholdDiscard = bufferSize
+	}
 }

--- a/group_options.go
+++ b/group_options.go
@@ -3,11 +3,11 @@ package syncs
 import "context"
 
 type options struct {
-	ctx             context.Context
-	preLock         bool
-	termOnError     bool
-	discardIfFull   bool
-	tresholdDiscard int
+	ctx           context.Context
+	preLock       bool
+	termOnError   bool
+	discardIfFull bool
+	tresholdSize  int
 }
 
 // GroupOption functional option type
@@ -36,18 +36,17 @@ func Discard(o *options) {
 	o.preLock = true // discard implies preemptive
 }
 
-// DiscardAfterTreshold works similarly to Discard, but buffers task until buffer treshold reach
-// For example, if 10 gouroutines are allowed and bufferTreshold is equal to 5, then 10 tasks
-// can run simultaneously in gouroutines and 5 tasks can be kept in buffer until gouroutines become
-// available.
-func DiscardAfterTreshold(bufferSize int) GroupOption {
+// DiscardAfterTreshold works similarly to Discard, but buffers tasks if all goroutines are busy
+// until the treshold size of 'active' tasks (i.e. executing and scheduled for execution) is achieved
+// If this value is lower than size, it will be ignored and common Discard mode will is used
+func DiscardAfterTreshold(tresholdSize int) GroupOption {
 	return func(o *options) {
 		o.discardIfFull = true
 		o.preLock = true
 
-		if bufferSize < 1 {
-			bufferSize = 0
+		if tresholdSize < 1 {
+			tresholdSize = 0
 		}
-		o.tresholdDiscard = bufferSize
+		o.tresholdSize = tresholdSize
 	}
 }

--- a/semaphore_test.go
+++ b/semaphore_test.go
@@ -41,16 +41,16 @@ func TestSemaphore(t *testing.T) {
 
 			// if number of locks are less than capacity, all should be acquired
 			if tt.lockTimes <= tt.capacity {
-				assert.Equal(t, int32(tt.lockTimes), atomic.LoadInt32(&locks))
+				assert.Equal(t, tt.lockTimes, int(atomic.LoadInt32(&locks)))
 				wg.Wait()
 				return
 			}
 			// if number of locks exceed capacity, it should hang after reaching the capacity
-			assert.Equal(t, int32(tt.capacity), atomic.LoadInt32(&locks))
+			assert.Equal(t, tt.capacity, int(atomic.LoadInt32(&locks)))
 			sema.Unlock()
 			time.Sleep(10 * time.Millisecond)
 			// after unlock, it should be able to acquire another lock
-			assert.Equal(t, int32(tt.capacity+1), atomic.LoadInt32(&locks))
+			assert.Equal(t, tt.capacity+1, int(atomic.LoadInt32(&locks)))
 			wg.Wait()
 		})
 	}
@@ -81,7 +81,7 @@ func TestSemaphore_TryLock(t *testing.T) {
 			}
 
 			// Check the acquired locks, it should not exceed capacity.
-			assert.Equal(t, int32(tt.expectedLocks), atomic.LoadInt32(&locks))
+			assert.Equal(t, tt.expectedLocks, int(atomic.LoadInt32(&locks)))
 		})
 	}
 }

--- a/sizedgroup.go
+++ b/sizedgroup.go
@@ -10,66 +10,123 @@ import (
 // SizedGroup interface enforces constructor usage and doesn't allow direct creation of sizedGroup
 type SizedGroup struct {
 	options
-	wg   sync.WaitGroup
-	sema Locker
+	wg            sync.WaitGroup
+	workers       chan struct{}
+	scheduledJobs chan struct{}
+	jobQueue      chan func(ctx context.Context)
+	workersMutex  sync.Mutex
 }
 
 // NewSizedGroup makes wait group with limited size alive goroutines
 func NewSizedGroup(size int, opts ...GroupOption) *SizedGroup {
-	res := SizedGroup{sema: NewSemaphore(size)}
+	if size < 1 {
+		size = 1
+	}
+	res := SizedGroup{workers: make(chan struct{}, size)}
 	res.options.ctx = context.Background()
 	for _, opt := range opts {
 		opt(&res.options)
 	}
+
+	// queue size either equal to number of workers or larger, otherwise does not make sense
+	queueSize := size
+	if res.tresholdDiscard > 0 {
+		queueSize += res.tresholdDiscard
+	}
+
+	res.jobQueue = make(chan func(ctx context.Context), queueSize)
+	res.scheduledJobs = make(chan struct{}, queueSize)
 	return &res
 }
 
 // Go calls the given function in a new goroutine.
 // Every call will be unblocked, but some goroutines may wait if semaphore locked.
 func (g *SizedGroup) Go(fn func(ctx context.Context)) {
-	canceled := func() bool {
-		select {
-		case <-g.ctx.Done():
-			return true
-		default:
-			return false
-		}
-	}
-
-	if canceled() {
+	if g.canceled() {
 		return
 	}
 
-	if g.preLock {
-		lockOk := g.sema.TryLock()
-		if !lockOk && g.discardIfFull {
-			// lock failed and discardIfFull is set, discard this goroutine
+	g.wg.Add(1)
+	if !g.preLock {
+		go func() {
+			defer g.wg.Done()
+			if g.canceled() {
+				return
+			}
+			g.scheduledJobs <- struct{}{}
+			fn(g.ctx)
+			<-g.scheduledJobs
+		}()
+		return
+	}
+
+	toRun := func(job func(ctx context.Context)) {
+		defer g.wg.Done()
+		if g.canceled() {
 			return
 		}
-		if !lockOk && !g.discardIfFull {
-			g.sema.Lock() // make sure we have block until lock is acquired
+		job(g.ctx)
+		<-g.scheduledJobs
+	}
+
+	startWorkerIfNeeded := func() {
+		g.workersMutex.Lock()
+		select {
+		case g.workers <- struct{}{}:
+			g.workersMutex.Unlock()
+			go func() {
+				for {
+					select {
+					case job := <-g.jobQueue:
+						toRun(job)
+					default:
+						g.workersMutex.Lock()
+						select {
+						case job := <-g.jobQueue:
+							g.workersMutex.Unlock()
+							toRun(job)
+							continue
+						default:
+							<-g.workers
+							g.workersMutex.Unlock()
+						}
+						return
+					}
+				}
+			}()
+		default:
+			g.workersMutex.Unlock()
 		}
 	}
 
-	g.wg.Add(1)
-	go func() {
-		defer g.wg.Done()
-
-		if canceled() {
-			return
+	if g.discardIfFull {
+		select {
+		case g.scheduledJobs <- struct{}{}:
+			g.jobQueue <- fn
+			startWorkerIfNeeded()
+		default:
+			g.wg.Done()
 		}
 
-		if !g.preLock {
-			g.sema.Lock()
-		}
+		return
+	}
 
-		fn(g.ctx)
-		g.sema.Unlock()
-	}()
+	g.scheduledJobs <- struct{}{}
+	g.jobQueue <- fn
+	startWorkerIfNeeded()
 }
 
 // Wait blocks until the SizedGroup counter is zero.
 // See sync.WaitGroup documentation for more information.
 func (g *SizedGroup) Wait() {
 	g.wg.Wait()
+}
+
+func (g *SizedGroup) canceled() bool {
+	select {
+	case <-g.ctx.Done():
+		return true
+	default:
+		return false
+	}
 }

--- a/sizedgroup.go
+++ b/sizedgroup.go
@@ -30,8 +30,8 @@ func NewSizedGroup(size int, opts ...GroupOption) *SizedGroup {
 
 	// queue size either equal to number of workers or larger, otherwise does not make sense
 	queueSize := size
-	if res.tresholdDiscard > 0 {
-		queueSize += res.tresholdDiscard
+	if res.tresholdSize > size {
+		queueSize = res.tresholdSize
 	}
 
 	res.jobQueue = make(chan func(ctx context.Context), queueSize)

--- a/sizedgroup_test.go
+++ b/sizedgroup_test.go
@@ -17,7 +17,7 @@ func TestSizedGroup(t *testing.T) {
 	var c uint32
 
 	for i := 0; i < 1000; i++ {
-		swg.Go(func(ctx context.Context) {
+		swg.Go(func(context.Context) {
 			time.Sleep(5 * time.Millisecond)
 			atomic.AddUint32(&c, 1)
 		})
@@ -32,7 +32,7 @@ func TestSizedGroup_Discard(t *testing.T) {
 	var c uint32
 
 	for i := 0; i < 100; i++ {
-		swg.Go(func(ctx context.Context) {
+		swg.Go(func(context.Context) {
 			time.Sleep(5 * time.Millisecond)
 			atomic.AddUint32(&c, 1)
 		})
@@ -42,19 +42,19 @@ func TestSizedGroup_Discard(t *testing.T) {
 	assert.Equal(t, uint32(10), c, fmt.Sprintf("%d, not all routines have been executed", c))
 }
 
-func TestSizedGroup_DiscardAfterTreshold(t *testing.T) {
-	swg := NewSizedGroup(10, DiscardAfterTreshold(10))
+func TestSizedGroup_WithWrongSizeValuePassed(t *testing.T) {
+	swg := NewSizedGroup(0, Discard)
 	var c uint32
 
 	for i := 0; i < 100; i++ {
-		swg.Go(func(ctx context.Context) {
+		swg.Go(func(context.Context) {
 			time.Sleep(5 * time.Millisecond)
 			atomic.AddUint32(&c, 1)
 		})
 	}
-	assert.True(t, runtime.NumGoroutine() < 15, "goroutines %d", runtime.NumGoroutine())
+	assert.True(t, runtime.NumGoroutine() < 6, "goroutines %d", runtime.NumGoroutine())
 	swg.Wait()
-	assert.Equal(t, uint32(20), c, fmt.Sprintf("%d, wrong number of routines have been executed", c))
+	assert.Equal(t, uint32(1), c, fmt.Sprintf("%d, wrong number of routines has been executed", c))
 }
 
 func TestSizedGroup_Preemptive(t *testing.T) {
@@ -72,14 +72,14 @@ func TestSizedGroup_Preemptive(t *testing.T) {
 	assert.Equal(t, uint32(100), c, fmt.Sprintf("%d, not all routines have been executed", c))
 }
 
-func TestSizedGroup_Canceled(t *testing.T) {
+func TestSizedGroup_CanceledPreemtiveMode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	swg := NewSizedGroup(10, Preemptive, Context(ctx))
 	var c uint32
 
 	for i := 0; i < 100; i++ {
-		swg.Go(func(ctx context.Context) {
+		swg.Go(func(context.Context) {
 			select {
 			case <-ctx.Done():
 				return
@@ -92,6 +92,71 @@ func TestSizedGroup_Canceled(t *testing.T) {
 	assert.True(t, c < 100)
 }
 
+func TestSizedGroup_CanceledNonPreemptiveMode(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	swg := NewSizedGroup(10, Context(ctx))
+	var c uint32
+
+	for i := 0; i < 2000; i++ {
+		swg.Go(func(context.Context) {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Millisecond):
+			}
+			atomic.AddUint32(&c, 1)
+		})
+	}
+	swg.Wait()
+	assert.True(t, c < 25)
+}
+
+func TestSizedGroup_DiscardAfterTreshold(t *testing.T) {
+	swg := NewSizedGroup(10, DiscardAfterTreshold(20))
+	var c uint32
+
+	for i := 0; i < 100; i++ {
+		swg.Go(func(context.Context) {
+			time.Sleep(5 * time.Millisecond)
+			atomic.AddUint32(&c, 1)
+		})
+	}
+	assert.True(t, runtime.NumGoroutine() < 15, "goroutines %d", runtime.NumGoroutine())
+	swg.Wait()
+	assert.Equal(t, uint32(20), c, fmt.Sprintf("%d, wrong number of routines have been executed", c))
+}
+
+func TestSizedGroup_DiscardAfterTreshold_WithNegativeTreshold(t *testing.T) {
+	swg := NewSizedGroup(10, DiscardAfterTreshold(-1))
+	var c uint32
+
+	for i := 0; i < 100; i++ {
+		swg.Go(func(context.Context) {
+			time.Sleep(5 * time.Millisecond)
+			atomic.AddUint32(&c, 1)
+		})
+	}
+	assert.True(t, runtime.NumGoroutine() < 15, "goroutines %d", runtime.NumGoroutine())
+	swg.Wait()
+	assert.Equal(t, uint32(10), c, fmt.Sprintf("%d, wrong number of routines have been executed", c))
+}
+
+func TestSizedGroup_DiscardAfterTreshold_WithTresholdNotAboveSize(t *testing.T) {
+	swg := NewSizedGroup(10, DiscardAfterTreshold(10))
+	var c uint32
+
+	for i := 0; i < 100; i++ {
+		swg.Go(func(context.Context) {
+			time.Sleep(5 * time.Millisecond)
+			atomic.AddUint32(&c, 1)
+		})
+	}
+	assert.True(t, runtime.NumGoroutine() < 15, "goroutines %d", runtime.NumGoroutine())
+	swg.Wait()
+	assert.Equal(t, uint32(10), c, fmt.Sprintf("%d, wrong number of routines have been executed", c))
+}
+
 // illustrates the use of a SizedGroup for concurrent, limited execution of goroutines.
 func ExampleSizedGroup_go() {
 
@@ -99,7 +164,7 @@ func ExampleSizedGroup_go() {
 
 	var c uint32
 	for i := 0; i < 1000; i++ {
-		grp.Go(func(ctx context.Context) { // Go call is non-blocking, like regular go statement
+		grp.Go(func(context.Context) { // Go call is non-blocking, like regular go statement
 			// do some work in 10 goroutines in parallel
 			atomic.AddUint32(&c, 1)
 			time.Sleep(10 * time.Millisecond)

--- a/sizedgroup_test.go
+++ b/sizedgroup_test.go
@@ -42,12 +42,27 @@ func TestSizedGroup_Discard(t *testing.T) {
 	assert.Equal(t, uint32(10), c, fmt.Sprintf("%d, not all routines have been executed", c))
 }
 
+func TestSizedGroup_DiscardAfterTreshold(t *testing.T) {
+	swg := NewSizedGroup(10, DiscardAfterTreshold(10))
+	var c uint32
+
+	for i := 0; i < 100; i++ {
+		swg.Go(func(ctx context.Context) {
+			time.Sleep(5 * time.Millisecond)
+			atomic.AddUint32(&c, 1)
+		})
+	}
+	assert.True(t, runtime.NumGoroutine() < 15, "goroutines %d", runtime.NumGoroutine())
+	swg.Wait()
+	assert.Equal(t, uint32(20), c, fmt.Sprintf("%d, wrong number of routines have been executed", c))
+}
+
 func TestSizedGroup_Preemptive(t *testing.T) {
 	swg := NewSizedGroup(10, Preemptive)
 	var c uint32
 
 	for i := 0; i < 100; i++ {
-		swg.Go(func(ctx context.Context) {
+		swg.Go(func(context.Context) {
 			time.Sleep(5 * time.Millisecond)
 			atomic.AddUint32(&c, 1)
 		})


### PR DESCRIPTION
…g channels

The change is inspired by the comment https://github.com/go-pkgz/syncs/issues/5#issuecomment-1504123418. The solution relies on channels as the main synchronization primitive, instead of semaphore.